### PR TITLE
Add Uber client experience under EPAM and update skills

### DIFF
--- a/resume_faangpath.tex
+++ b/resume_faangpath.tex
@@ -17,7 +17,7 @@
 
 \begin{rSection}{BRIEF SUMMARY}
 \linespread{1.0}
-{ I am a skilled Software Engineer with\textbf{ 3+ years experience} in building large-scale, scalable, \textbf{distributed systems}. Proficient in \textbf{Python, Java, Golang, Big-Data, Django, Spring Boot, SQL, Docker, AWS}. Effective communicator, able to work independently or collaboratively with stakeholders. Seeking opportunities to leverage experience for positive organizational impact }
+{ I am a skilled Software Engineer with\textbf{ 4+ years experience} in building large-scale, scalable, \textbf{distributed systems}. Proficient in \textbf{Python, Java, Golang, Big-Data, Django, Spring Boot, SQL, Docker, AWS}. Effective communicator, able to work independently or collaboratively with stakeholders. Seeking opportunities to leverage experience for positive organizational impact }
 
 
 \end{rSection}
@@ -44,17 +44,27 @@ Relevant Courses: Algorithms, Data Structures, Object-Oriented software developm
 \begin{rSection}{SKILLS}
 
 \begin{tabular}{ @{} >{\bfseries}l @{\hspace{6ex}} l }
-Technical Skills & Django, Springboot, Rest API, AWS, GCP, PyTorch \\
-Database:  & SQL, MySQL, NoSQL, MongoDB, Vertica, Redis, Aerospike, postgresql\\
-Programming & Python, Java, Golang, C++\\
-Miscellaneous & Docker, Microservices, Distributed System, Cloud services, Agile, Git, Machine Learning,\\ & Rest API, Deep Learning, NLP, AI\\
+Platforms & Docker, Google Cloud Platform, Amazon Web Services \\
+Data & Amazon RDS, NoSQL Databases, PostgreSQL, MySQL, Redis, MongoDB, Aerospike, Amazon DynamoDB \\
+Computer Languages & Python, SQL, Java 8, Java \\
+Frameworks & Spring Data, Hibernate, Spring Core, JUnit, Spring Security, PyTorch, Mockito, Django, Spring Boot, JUnit 5, Spring MVC \\
+Web/Application Servers & Web Services \\
+Solutions & Postman, Amazon S3, AWS CloudFormation, Amazon Elastic File System, Amazon EC2 \\
+Standards & API \& Integration Standards, REST API \\
 \end{tabular}\\
 \end{rSection}
 
 \begin{rSection}{EXPERIENCE}
 
-\textbf{Software Engineer 2}, EPAM \hfill July 2024 - current\\
- \hfill \textit{Banagalore, Karnataka}
+\textbf{Software Engineer 2}, EPAM (Client: Uber) \hfill Jul 2024 - Present\\
+ \hfill \textit{Bangalore, Karnataka}
+ \begin{itemize}
+    \itemsep -6pt
+    \item Led the YARPC migration for Uber, ensuring end-to-end migration of multiple critical microservices from legacy TChannel transport to the modern, scalable YARPC framework.
+    \item Refactored service interfaces and handlers using Java 8+, enabling support for YARPC HTTP/gRPC transports and Thrift/Protobuf encoding while maintaining API contract integrity.
+    \item Integrated YARPC-based services with Spring Boot, ensuring clean separation of transport and business logic via modular service layers.
+    \item Documented migration patterns, reusable templates, and best practices for broader team adoption across Java microservices.
+ \end{itemize}
 
 \textbf{Software Engineer 2}, Sandvine \hfill Oct 2021 - June 2024\\
  \hfill \textit{Bangalore, Karnataka}


### PR DESCRIPTION
## Summary
- Update summary to reflect 4+ years of experience
- Refresh skills section with additional platforms, data stores, frameworks, and standards
- Consolidate Uber YARPC work as an EPAM client project instead of a separate role

## Testing
- ⚠️ `dart format .` *(command not found: dart)*
- ✅ `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fca2dd80c8320bdfee17205fab46e